### PR TITLE
feat: Enhance JOIN event handling to preserve existing notifications …

### DIFF
--- a/src/sessionNotificationService.ts
+++ b/src/sessionNotificationService.ts
@@ -101,7 +101,46 @@ export class SessionNotificationService {
   ): Promise<void> {
     const { username } = sessionEvent;
 
-    // Check if user is in cooldown period
+    // First, check if there's an existing notification with pending deletion
+    const existingNotification = await this.database.findActiveJoinNotification(
+      username,
+      this.config.whoIsOnChannelId
+    );
+
+    if (existingNotification?.discordMessageId) {
+      // Cancel any pending deletion timeout
+      const timeoutKey = `${username}-${existingNotification.discordMessageId}`;
+      const existingTimeout = this.deletionTimeouts.get(timeoutKey);
+      if (existingTimeout) {
+        clearTimeout(existingTimeout);
+        this.deletionTimeouts.delete(timeoutKey);
+        this.logger.debug(
+          "Cancelled pending deletion for existing notification",
+          {
+            username,
+            messageId: existingNotification.discordMessageId,
+          }
+        );
+      }
+
+      // Update database to mark user as online (cancel scheduled deletion)
+      await this.database.recordSessionNotification({
+        username,
+        type: "JOIN",
+        discordMessageId: existingNotification.discordMessageId,
+        discordChannelId: discordChannel.id,
+        discordGuildId: discordChannel.guild.id,
+        expiresAt: new Date(Date.now() + this.config.deletionDelayMs),
+      });
+
+      this.logger.info("User rejoined - existing notification preserved", {
+        username,
+        messageId: existingNotification.discordMessageId,
+      });
+      return;
+    }
+
+    // Check if user is in cooldown period for new notifications
     const cooldownStatus = await this.database.checkSessionCooldown(
       username,
       "JOIN"
@@ -115,7 +154,7 @@ export class SessionNotificationService {
       return;
     }
 
-    // Create and send JOIN notification
+    // Create and send new JOIN notification
     const embed = this.discordFormatter.createSessionJoinEmbed(sessionEvent);
     const content = this.discordFormatter.createSessionNotificationText(
       sessionEvent,

--- a/src/sessionNotificationService.ts
+++ b/src/sessionNotificationService.ts
@@ -123,7 +123,7 @@ export class SessionNotificationService {
         );
       }
 
-      // Update database to mark user as online (cancel scheduled deletion)
+      // Update existing notification expiration time to extend its lifecycle
       await this.database.recordSessionNotification({
         username,
         type: "JOIN",


### PR DESCRIPTION
This pull request updates the session notification logic to better handle cases where a user rejoins before their previous notification is deleted. Now, if a user rejoins while a previous notification is pending deletion, the system cancels the deletion and updates the notification instead of sending a new one. This prevents duplicate notifications and ensures users' online status is accurately reflected.

**Improvements to session notification handling:**

* Added logic to check for an existing active join notification for a user before sending a new one. If found, cancels any pending deletion timeout, updates the notification's expiry, and avoids sending a duplicate notification.
* Updated the flow to only check the cooldown period for new notifications if no active notification exists, ensuring that cooldown does not interfere with notification preservation.

**Notification creation behavior:**

* Clarified code and comments to distinguish between creating a new JOIN notification and updating an existing one.…and cancel pending deletions