### PR TITLE
double logging

### DIFF
--- a/src/logParser.ts
+++ b/src/logParser.ts
@@ -241,6 +241,14 @@ export class LogParserService {
     )) {
       if (activityType === "DEATH") continue; // Deaths handled separately
 
+      // Skip JOIN/LEAVE if session callback is registered (they're handled separately)
+      if (
+        (activityType === "JOIN" || activityType === "LEAVE") &&
+        this.onSessionEventCallback
+      ) {
+        continue;
+      }
+
       const match = pattern.exec(logLine);
       if (match) {
         activities.push({

--- a/src/playerTracker.ts
+++ b/src/playerTracker.ts
@@ -220,8 +220,8 @@ export class PlayerTracker {
         lastDeathTimestamp: deathEvent.timestamp.toISOString(),
       });
 
-      // Also use legacy storage method for backward compatibility
-      await this.storageService.storeDeath(deathEvent);
+      // Note: Death is already stored as activity via recordActivity() above
+      // No need to call storageService.storeDeath() which would duplicate logging
 
       return {
         recorded: true,


### PR DESCRIPTION
This pull request refines how session and death events are handled to avoid duplicate processing and storage. Specifically, it ensures that JOIN/LEAVE events are not redundantly processed when a session callback is present, and prevents duplicate logging of death events.

**Session and activity event handling:**
- In `LogParserService`, JOIN and LEAVE events are now skipped during activity parsing if a session event callback (`onSessionEventCallback`) is registered, since those events are handled separately in that case.

**Death event storage:**
- In `PlayerTracker`, the legacy storage method for death events (`storageService.storeDeath`) has been removed to prevent duplicate logging, as deaths are already recorded via the main activity recording mechanism.